### PR TITLE
✨ Feat: 기사 조회 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/monewteam08/MonewTeam08Application.java
+++ b/src/main/java/com/example/monewteam08/MonewTeam08Application.java
@@ -2,12 +2,14 @@ package com.example.monewteam08;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MonewTeam08Application {
 
-    public static void main(String[] args) {
-        SpringApplication.run(MonewTeam08Application.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(MonewTeam08Application.class, args);
+  }
 
 }

--- a/src/main/java/com/example/monewteam08/controller/ArticleController.java
+++ b/src/main/java/com/example/monewteam08/controller/ArticleController.java
@@ -1,14 +1,19 @@
 package com.example.monewteam08.controller;
 
+import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
 import com.example.monewteam08.exception.article.ArticleNotFoundException;
 import com.example.monewteam08.service.Interface.ArticleService;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -40,5 +45,35 @@ public class ArticleController {
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+  }
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseArticleDto> getArticles(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) UUID interestId,
+      @RequestParam(required = false) List<String> sourceIn,
+      @RequestParam(required = false) LocalDateTime publishDateFrom,
+      @RequestParam(required = false) LocalDateTime publishDateTo,
+      @RequestParam String orderBy,
+      @RequestParam String direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) LocalDateTime after, //createdAt
+      @RequestParam int limit,
+      @RequestParam UUID monewRequestUserId
+  ) {
+    CursorPageResponseArticleDto response = articleService.getArticles(
+        keyword,
+        interestId,
+        sourceIn,
+        publishDateFrom,
+        publishDateTo,
+        orderBy,
+        direction,
+        cursor,
+        after,
+        limit,
+        monewRequestUserId
+    );
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/example/monewteam08/controller/ArticleController.java
+++ b/src/main/java/com/example/monewteam08/controller/ArticleController.java
@@ -1,0 +1,44 @@
+package com.example.monewteam08.controller;
+
+import com.example.monewteam08.exception.article.ArticleNotFoundException;
+import com.example.monewteam08.service.Interface.ArticleService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/articles")
+@RequiredArgsConstructor
+public class ArticleController {
+
+  private final ArticleService articleService;
+
+  @DeleteMapping("/{articleId}")
+  public ResponseEntity<Void> softDelete(@PathVariable UUID articleId) {
+    try {
+      articleService.softDelete(articleId);
+      return ResponseEntity.noContent().build();
+    } catch (ArticleNotFoundException e) {
+      return ResponseEntity.notFound().build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @DeleteMapping("/{articleId}/hard")
+  public ResponseEntity<Void> hardDelete(@PathVariable UUID articleId) {
+    try {
+      articleService.hardDelete(articleId);
+      return ResponseEntity.noContent().build();
+    } catch (ArticleNotFoundException e) {
+      return ResponseEntity.notFound().build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+}

--- a/src/main/java/com/example/monewteam08/dto/response/article/ArticleDto.java
+++ b/src/main/java/com/example/monewteam08/dto/response/article/ArticleDto.java
@@ -1,16 +1,18 @@
 package com.example.monewteam08.dto.response.article;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public class ArticleDto {
+public record ArticleDto(
+    @NotNull UUID id,
+    @NotNull String source,
+    @NotNull String sourceUrl,
+    @NotNull String title,
+    @NotNull LocalDateTime publishedAt,
+    @NotNull String summary,
+    long viewCount,
+    boolean viewedByMe
+) {
 
-  private UUID id;
-  private String source;
-  private String sourceUrl;
-  private String title;
-  private LocalDateTime publishedAt;
-  private String summary;
-  private long viewCount;
-  private boolean viewedByMe;
 }

--- a/src/main/java/com/example/monewteam08/dto/response/article/CursorPageResponseArticleDto.java
+++ b/src/main/java/com/example/monewteam08/dto/response/article/CursorPageResponseArticleDto.java
@@ -1,0 +1,15 @@
+package com.example.monewteam08.dto.response.article;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CursorPageResponseArticleDto(
+    List<ArticleDto> articles,
+    String nextCursor,
+    LocalDateTime nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/example/monewteam08/entity/Article.java
+++ b/src/main/java/com/example/monewteam08/entity/Article.java
@@ -21,8 +21,13 @@ public class Article {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private UUID id;
 
+  @Column(name = "source")
   private String source;
+
+  @Column(name = "title")
   private String title;
+
+  @Column(name = "summary", columnDefinition = "TEXT")
   private String summary;
 
   @Column(name = "source_url", unique = true)

--- a/src/main/java/com/example/monewteam08/entity/Article.java
+++ b/src/main/java/com/example/monewteam08/entity/Article.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "articles")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Article {
 
   @Id
@@ -49,5 +49,9 @@ public class Article {
     this.summary = summary;
     this.sourceUrl = sourceUrl;
     this.publishedAt = publishedAt;
+  }
+
+  public void softDelete() {
+    this.isActive = false;
   }
 }

--- a/src/main/java/com/example/monewteam08/entity/UserArticleView.java
+++ b/src/main/java/com/example/monewteam08/entity/UserArticleView.java
@@ -1,0 +1,30 @@
+package com.example.monewteam08.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Entity
+@Table(name = "user_article_views")
+@Getter
+public class UserArticleView {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Column(name = "article_id", nullable = false)
+  private UUID articleId;
+
+  @Column(name = "viewed_at")
+  private LocalDateTime viewedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/example/monewteam08/exception/ErrorCode.java
+++ b/src/main/java/com/example/monewteam08/exception/ErrorCode.java
@@ -7,29 +7,34 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    // COMMON
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON000", "서버 에러, 관리자에게 연락해주세요."),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON001", "잘못된 값을 입력하였습니다"),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON002", "요청한 리소스를 찾을 수 없습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON003", "허용되지 않은 HTTP 메서드입니다."),
+  // COMMON
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON000", "서버 에러, 관리자에게 연락해주세요."),
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON001", "잘못된 값을 입력하였습니다"),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON002", "요청한 리소스를 찾을 수 없습니다."),
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON003", "허용되지 않은 HTTP 메서드입니다."),
 
-    // DATABASE (DB 처리 관련)
-    FAILED_TO_SAVE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE001", "데이터 저장에 실패하였습니다."),
-    FAILED_TO_LOAD_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE002", "데이터 로딩에 실패하였습니다."),
-    FAILED_TO_UPDATE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE003", "데이터 갱신에 실패하였습니다."),
-    FAILED_TO_DELETE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE004", "데이터 삭제에 실패하였습니다."),
+  // DATABASE (DB 처리 관련)
+  FAILED_TO_SAVE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE001", "데이터 저장에 실패하였습니다."),
+  FAILED_TO_LOAD_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE002", "데이터 로딩에 실패하였습니다."),
+  FAILED_TO_UPDATE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE003", "데이터 갱신에 실패하였습니다."),
+  FAILED_TO_DELETE_DATA(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE004", "데이터 삭제에 실패하였습니다."),
 
-    // Auth
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH001", "로그인에 실패했습니다."),
+  // Auth
+  LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH001", "로그인에 실패했습니다."),
 
-    //댓글
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT001", "댓글을 찾을 수 없습니다."),
-    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "COMMENT002", "댓글을 수정/삭제 할 권한이 없습니다."),
+  //댓글
+  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT001", "댓글을 찾을 수 없습니다."),
+  UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "COMMENT002", "댓글을 수정/삭제 할 권한이 없습니다."),
 
-    // User
-    EMAIL_IS_ALREADY_EXIST(HttpStatus.CONFLICT, "USER001", "이미 사용 중인 이메일입니다.");
+  // User
+  EMAIL_IS_ALREADY_EXIST(HttpStatus.CONFLICT, "USER001", "이미 사용 중인 이메일입니다."),
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+  // Article
+  ARTICLE_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ARTICLE001", "기사 가져오기에 실패했습니다."),
+  ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE002", "기사를 찾을 수 없습니다."),
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
 }

--- a/src/main/java/com/example/monewteam08/exception/article/ArticleFetchFailedException.java
+++ b/src/main/java/com/example/monewteam08/exception/article/ArticleFetchFailedException.java
@@ -1,0 +1,12 @@
+package com.example.monewteam08.exception.article;
+
+import com.example.monewteam08.exception.ErrorCode;
+import com.example.monewteam08.exception.MonewException;
+import java.util.Map;
+
+public class ArticleFetchFailedException extends MonewException {
+
+  public ArticleFetchFailedException(String source) {
+    super(ErrorCode.ARTICLE_FETCH_FAILED, Map.of("source", source));
+  }
+}

--- a/src/main/java/com/example/monewteam08/exception/article/ArticleNotFoundException.java
+++ b/src/main/java/com/example/monewteam08/exception/article/ArticleNotFoundException.java
@@ -1,0 +1,13 @@
+package com.example.monewteam08.exception.article;
+
+import com.example.monewteam08.exception.ErrorCode;
+import com.example.monewteam08.exception.MonewException;
+import java.util.Map;
+import java.util.UUID;
+
+public class ArticleNotFoundException extends MonewException {
+
+  public ArticleNotFoundException(UUID id) {
+    super(ErrorCode.ARTICLE_NOT_FOUND, Map.of("id", id));
+  }
+}

--- a/src/main/java/com/example/monewteam08/mapper/ArticleMapper.java
+++ b/src/main/java/com/example/monewteam08/mapper/ArticleMapper.java
@@ -1,0 +1,22 @@
+package com.example.monewteam08.mapper;
+
+import com.example.monewteam08.dto.response.article.ArticleDto;
+import com.example.monewteam08.entity.Article;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArticleMapper {
+
+  public ArticleDto toDto(Article article, boolean viewedByMe) {
+    return new ArticleDto(
+        article.getId(),
+        article.getSource(),
+        article.getSourceUrl(),
+        article.getTitle(),
+        article.getPublishedAt(),
+        article.getSummary(),
+        article.getViewCount(),
+        viewedByMe
+    );
+  }
+}

--- a/src/main/java/com/example/monewteam08/repository/ArticleRepository.java
+++ b/src/main/java/com/example/monewteam08/repository/ArticleRepository.java
@@ -2,10 +2,17 @@ package com.example.monewteam08.repository;
 
 import com.example.monewteam08.entity.Article;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ArticleRepository extends JpaRepository<Article, UUID> {
+public interface ArticleRepository extends JpaRepository<Article, UUID>,
+    JpaSpecificationExecutor<Article> {
+
+  Page<Article> findAllByIsActiveTrue(Specification<Article> spec, Pageable pageable);
 
 }

--- a/src/main/java/com/example/monewteam08/scheduler/ArticleScheduler.java
+++ b/src/main/java/com/example/monewteam08/scheduler/ArticleScheduler.java
@@ -1,0 +1,18 @@
+package com.example.monewteam08.scheduler;
+
+import com.example.monewteam08.service.Interface.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleScheduler {
+
+  private final ArticleService articleService;
+
+  @Scheduled(cron = "0 0 * * * *")
+  public void fetchAndSaveArticles() {
+    articleService.save();
+  }
+}

--- a/src/main/java/com/example/monewteam08/scheduler/ArticleScheduler.java
+++ b/src/main/java/com/example/monewteam08/scheduler/ArticleScheduler.java
@@ -1,15 +1,23 @@
 package com.example.monewteam08.scheduler;
 
 import com.example.monewteam08.service.Interface.ArticleService;
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.PostConstruct;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class ArticleScheduler {
 
   private final ArticleService articleService;
+
+  public ArticleScheduler(ArticleService articleService) {
+    this.articleService = articleService;
+  }
+
+  @PostConstruct
+  public void init() {
+    articleService.save();
+  }
 
   @Scheduled(cron = "0 0 * * * *")
   public void fetchAndSaveArticles() {

--- a/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
+++ b/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
@@ -1,0 +1,10 @@
+package com.example.monewteam08.service.Interface;
+
+import com.example.monewteam08.dto.response.article.ArticleDto;
+import java.util.List;
+
+public interface ArticleService {
+
+  List<ArticleDto> save();
+
+}

--- a/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
+++ b/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
@@ -2,6 +2,7 @@ package com.example.monewteam08.service.Interface;
 
 import com.example.monewteam08.dto.response.article.ArticleDto;
 import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -9,7 +10,10 @@ public interface ArticleService {
 
   List<ArticleDto> save();
 
-  CursorPageResponseArticleDto getArticles();
+  CursorPageResponseArticleDto getArticles(String keyword,
+      UUID interestId, List<String> sourceIn, LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo, String orderBy, String direction,
+      String cursor, LocalDateTime after, int limit, UUID userId);
 
   void softDelete(UUID id);
 

--- a/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
+++ b/src/main/java/com/example/monewteam08/service/Interface/ArticleService.java
@@ -1,10 +1,17 @@
 package com.example.monewteam08.service.Interface;
 
 import com.example.monewteam08.dto.response.article.ArticleDto;
+import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
 import java.util.List;
+import java.util.UUID;
 
 public interface ArticleService {
 
   List<ArticleDto> save();
 
+  CursorPageResponseArticleDto getArticles();
+
+  void softDelete(UUID id);
+
+  void hardDelete(UUID id);
 }

--- a/src/main/java/com/example/monewteam08/service/impl/ArticleFetchServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/ArticleFetchServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.monewteam08.service.impl;
 
 import com.example.monewteam08.dto.response.article.NaverNewsResponse;
 import com.example.monewteam08.entity.Article;
+import com.example.monewteam08.exception.article.ArticleFetchFailedException;
 import com.example.monewteam08.service.Interface.ArticleFetchService;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
@@ -108,7 +109,7 @@ public class ArticleFetchServiceImpl implements ArticleFetchService {
                 publishedAt));
       }
     } catch (IOException | FeedException e) {
-      throw new RuntimeException(source + " 수집 중 에러", e);
+      throw new ArticleFetchFailedException(source);
     }
     return articles;
   }

--- a/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
@@ -1,12 +1,15 @@
 package com.example.monewteam08.service.impl;
 
 import com.example.monewteam08.dto.response.article.ArticleDto;
+import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
 import com.example.monewteam08.entity.Article;
+import com.example.monewteam08.exception.article.ArticleNotFoundException;
 import com.example.monewteam08.mapper.ArticleMapper;
 import com.example.monewteam08.repository.ArticleRepository;
 import com.example.monewteam08.service.Interface.ArticleFetchService;
 import com.example.monewteam08.service.Interface.ArticleService;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +20,6 @@ public class ArticleServiceImpl implements ArticleService {
   private final ArticleRepository articleRepository;
   private final ArticleFetchService articleFetchService;
   private final ArticleMapper articleMapper;
-
 
   @Override
   public List<ArticleDto> save() {
@@ -30,6 +32,27 @@ public class ArticleServiceImpl implements ArticleService {
         .toList();
   }
 
+  @Override
+  public CursorPageResponseArticleDto getArticles() {
+
+    return null;
+  }
+
+  @Override
+  public void softDelete(UUID id) {
+    Article article = articleRepository.findById(id)
+        .orElseThrow(() -> new ArticleNotFoundException(id));
+    article.softDelete();
+    articleRepository.save(article);
+  }
+
+  @Override
+  public void hardDelete(UUID id) {
+    Article article = articleRepository.findById(id)
+        .orElseThrow(() -> new ArticleNotFoundException(id));
+    articleRepository.delete(article);
+  }
+
   protected List<Article> filterWithKeywords(List<Article> articles) {
     List<String> keywords = List.of("경제"); // 관심사 서비스 반영 예정
 
@@ -38,6 +61,7 @@ public class ArticleServiceImpl implements ArticleService {
             .anyMatch(keyword ->
                 article.getTitle().contains(keyword) || article.getSummary().contains(keyword)))
         .toList();
-
   }
+
+
 }

--- a/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
@@ -8,9 +8,16 @@ import com.example.monewteam08.mapper.ArticleMapper;
 import com.example.monewteam08.repository.ArticleRepository;
 import com.example.monewteam08.service.Interface.ArticleFetchService;
 import com.example.monewteam08.service.Interface.ArticleService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -33,9 +40,40 @@ public class ArticleServiceImpl implements ArticleService {
   }
 
   @Override
-  public CursorPageResponseArticleDto getArticles() {
+  public CursorPageResponseArticleDto getArticles(String keyword,
+      UUID interestId, List<String> sourceIn, LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo, String orderBy, String direction,
+      String cursor, LocalDateTime after, int limit, UUID userId) {
 
-    return null;
+    Pageable pageable = createPageable(limit, orderBy, direction, "publishedAt", "desc");
+    Specification<Article> spec = getSpec(keyword, interestId, sourceIn, publishDateFrom,
+        publishDateTo, after);
+
+    Page<Article> articles = articleRepository.findAllByIsActiveTrue(spec, pageable);
+
+    List<ArticleDto> articleDtos = articles.stream()
+        .map(article -> articleMapper.toDto(article,
+            false)) //ArticleView에서 userId 있는지 확인 추가 필요, 임시로 false 처리
+        .toList();
+
+    String nextCursor = null;
+    LocalDateTime nextAfter = null;
+
+    if (articles.hasNext()) {
+      LocalDateTime lastPublishedAt = articles.getContent().get(articles.getNumberOfElements() - 1)
+          .getPublishedAt();
+      nextCursor = lastPublishedAt.toString();
+      nextAfter = lastPublishedAt;
+    }
+
+    return new CursorPageResponseArticleDto(
+        articleDtos,
+        nextCursor,
+        nextAfter,
+        articles.getSize(),
+        articles.getTotalElements(),
+        articles.hasNext()
+    );
   }
 
   @Override
@@ -61,6 +99,64 @@ public class ArticleServiceImpl implements ArticleService {
             .anyMatch(keyword ->
                 article.getTitle().contains(keyword) || article.getSummary().contains(keyword)))
         .toList();
+  }
+
+  private Pageable createPageable(int limit, String sortField, String sortDirection,
+      String defaultSortField, String defaultSortDirection) {
+    if (limit <= 0) {
+      limit = 50;
+    }
+
+    Sort sort;
+    Direction direction;
+    if (sortField != null && !sortField.isEmpty()) {
+      direction = "desc".equalsIgnoreCase(sortDirection) ? Sort.Direction.DESC : Sort.Direction.ASC;
+      sort = Sort.by(direction, sortField);
+    } else {
+      direction =
+          "desc".equalsIgnoreCase(defaultSortDirection) ? Sort.Direction.DESC : Sort.Direction.ASC;
+      sort = Sort.by(direction, defaultSortField);
+    }
+
+    return PageRequest.of(0, limit, sort);
+  }
+
+  private Specification<Article> getSpec(String keyword, UUID interestId,
+      List<String> sourceIn, LocalDateTime publishDateFrom,
+      LocalDateTime publishDateTo, LocalDateTime after) {
+    Specification<Article> spec = Specification.where(null);
+
+    if (keyword != null) {
+      spec = spec.and((root, query, cb) -> cb.or(
+          cb.like(root.get("title"), "%" + keyword + "%"),
+          cb.like(root.get("summary"), "%" + keyword + "%")
+      ));
+    }
+    if (interestId != null) {
+      spec = spec.and((root, query, cb) -> cb.equal(root.get("interestId"), interestId));
+    }
+
+    if (sourceIn != null && !sourceIn.isEmpty()) {
+      spec = spec.and((root, query, cb) -> root.get("source").in(sourceIn));
+    }
+
+    if (publishDateFrom != null && publishDateTo != null) {
+      spec = spec.and(
+          (root, query, cb) -> cb.between(root.get("publishedAt"), publishDateFrom, publishDateTo));
+    } else if (publishDateFrom != null && publishDateTo == null) {
+      spec = spec.and(
+          (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("publishedAt"), publishDateFrom));
+    } else if (publishDateFrom == null && publishDateTo != null) {
+      spec = spec.and(
+          (root, query, cb) -> cb.lessThanOrEqualTo(root.get("publishedAt"), publishDateTo));
+    }
+
+    if (after != null) {
+      spec = spec.and(
+          (root, query, cb) -> cb.lessThan(root.get("publishedAt"), after));
+    }
+
+    return spec;
   }
 
 

--- a/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/ArticleServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.monewteam08.service.impl;
+
+import com.example.monewteam08.dto.response.article.ArticleDto;
+import com.example.monewteam08.entity.Article;
+import com.example.monewteam08.mapper.ArticleMapper;
+import com.example.monewteam08.repository.ArticleRepository;
+import com.example.monewteam08.service.Interface.ArticleFetchService;
+import com.example.monewteam08.service.Interface.ArticleService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleServiceImpl implements ArticleService {
+
+  private final ArticleRepository articleRepository;
+  private final ArticleFetchService articleFetchService;
+  private final ArticleMapper articleMapper;
+
+
+  @Override
+  public List<ArticleDto> save() {
+    List<Article> articles = articleFetchService.fetchAllArticles();
+    List<Article> filteredArticles = filterWithKeywords(articles);
+    List<Article> savedArticles = articleRepository.saveAll(filteredArticles);
+
+    return savedArticles.stream()
+        .map(article -> articleMapper.toDto(article, false))
+        .toList();
+  }
+
+  protected List<Article> filterWithKeywords(List<Article> articles) {
+    List<String> keywords = List.of("경제"); // 관심사 서비스 반영 예정
+
+    return articles.stream()
+        .filter(article -> keywords.stream()
+            .anyMatch(keyword ->
+                article.getTitle().contains(keyword) || article.getSummary().contains(keyword)))
+        .toList();
+
+  }
+}

--- a/src/test/java/com/example/monewteam08/controller/ArticleControllerTest.java
+++ b/src/test/java/com/example/monewteam08/controller/ArticleControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.monewteam08.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.monewteam08.service.Interface.ArticleService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ArticleController.class)
+public class ArticleControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private ArticleService articleService;
+
+  @Test
+  void 기사_논리_삭제_API_성공() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/articles/{id}", articleId))
+        .andExpect(status().isNoContent());
+
+    verify(articleService).softDelete(articleId);
+  }
+
+  @Test
+  void 기사_물리_삭제_API_성공() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+
+    // when & then
+    mockMvc.perform(delete("/api/articles/{id}/hard", articleId))
+        .andExpect(status().isNoContent());
+
+    verify(articleService).hardDelete(articleId);
+  }
+
+}

--- a/src/test/java/com/example/monewteam08/service/impl/ArticleServiceTest.java
+++ b/src/test/java/com/example/monewteam08/service/impl/ArticleServiceTest.java
@@ -1,0 +1,32 @@
+package com.example.monewteam08.service.impl;
+
+import com.example.monewteam08.entity.Article;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleServiceTest {
+
+  @InjectMocks
+  private ArticleServiceImpl articleService;
+
+  @Test
+  public void 기사_키워드_필터링() {
+    // given
+    List<Article> articles = List.of(
+        new Article("NAVER", "오늘의 경제 뉴스", "경제가 어렵습니다", "http://a.com", LocalDateTime.now()),
+        new Article("NAVER", "오늘의 연예 뉴스", "연예계 소식입니다", "http://b.com", LocalDateTime.now()),
+        new Article("NAVER", "경제 회복 중", "경제 성장률이 증가 중", "http://c.com", LocalDateTime.now())
+    );
+
+    // when
+    List<Article> filteredArticles = articleService.filterWithKeywords(articles);
+
+    // then
+    assert (filteredArticles.size() == 2);
+  }
+}

--- a/src/test/java/com/example/monewteam08/service/impl/ArticleServiceTest.java
+++ b/src/test/java/com/example/monewteam08/service/impl/ArticleServiceTest.java
@@ -1,15 +1,30 @@
 package com.example.monewteam08.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.monewteam08.dto.response.article.ArticleDto;
+import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
 import com.example.monewteam08.entity.Article;
+import com.example.monewteam08.repository.ArticleRepository;
+import java.lang.reflect.Constructor;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ArticleServiceTest {
+
+  @Mock
+  private ArticleRepository articleRepository;
 
   @InjectMocks
   private ArticleServiceImpl articleService;
@@ -28,5 +43,78 @@ public class ArticleServiceTest {
 
     // then
     assert (filteredArticles.size() == 2);
+  }
+
+  @Test
+  void 기사_목록_조회_성공() {
+    // given
+    UUID articleId = UUID.randomUUID();
+    ArticleDto dto = new ArticleDto(
+        articleId,
+        "NAVER",
+        "https://naver.com/article/123",
+        "테스트 제목",
+        LocalDateTime.parse("2025-04-22T02:20:37.781"),
+        "요약 내용",
+        100L,
+        true
+    );
+    CursorPageResponseArticleDto response = new CursorPageResponseArticleDto(
+        List.of(dto),
+        "next-cursor",
+        LocalDateTime.parse("2025-04-06T15:04:05"),
+        10,
+        100,
+        true
+    );
+
+    given(articleService.getArticles()).willReturn(response);
+
+    // when
+    CursorPageResponseArticleDto result = articleService.getArticles();
+
+    // then
+    assertThat(result.articles()).hasSize(1);
+    assertThat(result.totalElements()).isEqualTo(100);
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.articles().get(0).viewedByMe()).isTrue();
+  }
+
+  @Test
+  void 기사_논리_삭제_성공() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+    Constructor<Article> constructor = Article.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    Article article = constructor.newInstance();
+    ReflectionTestUtils.setField(article, "id", articleId);
+    ReflectionTestUtils.setField(article, "isActive", false);
+
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+
+    // when
+    articleService.softDelete(articleId);
+
+    // then
+    assertThat(article.isActive()).isFalse();
+    verify(articleRepository).save(article);
+  }
+
+  @Test
+  void 기사_물리_삭제_성공() throws Exception {
+    // given
+    UUID articleId = UUID.randomUUID();
+    Constructor<Article> constructor = Article.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    Article article = constructor.newInstance();
+    ReflectionTestUtils.setField(article, "id", articleId);
+
+    given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+
+    // when
+    articleService.hardDelete(articleId);
+
+    // then
+    verify(articleRepository).delete(article);
   }
 }


### PR DESCRIPTION
## #️⃣ 16

### 🎯 PR 개요
 - 기사 조회 및 삭제 API 구현
  
### 📑 작업 내용

- 기사 목록 조회 API 
- 기사 논리적 작제 
- 기사 물리적 삭제

#### 🛠 테스트 내용 (선택)

> 변경 사항을 어떻게 테스트했는지 설명해주세요.
> (예: 유닛 테스트, 통합 테스트 등)

### 📝 참고 사항 (선택)

> 관련된 이슈, 문서 또는 추가 설명이 필요하면 작성해주세요.

### 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 기사(Article) 조회, 필터링, 정렬, 커서 기반 페이지네이션 API가 추가되었습니다.
  - 기사 논리 삭제(soft delete) 및 물리 삭제(hard delete) 기능이 제공됩니다.
  - 기사 조회수 및 사용자별 기사 열람 기록이 관리됩니다.
  - 기사 데이터가 매시 정각마다 자동으로 갱신됩니다.

- **버그 수정**
  - 기사 관련 예외 처리 및 오류 메시지가 개선되었습니다.

- **리팩터**
  - 기사 DTO 구조가 불변 레코드로 변경되고, 필수 필드에 대한 유효성 검증이 추가되었습니다.

- **테스트**
  - 기사 API 및 서비스의 주요 기능(조회, 삭제, 필터링)에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->