### PR TITLE
Feat: S3 업로드, 다운로드 로직 추가

### DIFF
--- a/src/main/java/com/example/monewteam08/MonewTeam08Application.java
+++ b/src/main/java/com/example/monewteam08/MonewTeam08Application.java
@@ -1,11 +1,14 @@
 package com.example.monewteam08;
 
+import com.example.monewteam08.config.BackupS3Properties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableConfigurationProperties(BackupS3Properties.class)
 public class MonewTeam08Application {
 
   public static void main(String[] args) {

--- a/src/main/java/com/example/monewteam08/config/AwsS3Config.java
+++ b/src/main/java/com/example/monewteam08/config/AwsS3Config.java
@@ -1,0 +1,19 @@
+package com.example.monewteam08.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .region(Region.AP_NORTHEAST_2)
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+}

--- a/src/main/java/com/example/monewteam08/config/BackupS3Properties.java
+++ b/src/main/java/com/example/monewteam08/config/BackupS3Properties.java
@@ -1,0 +1,18 @@
+package com.example.monewteam08.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "backup.s3")
+public class BackupS3Properties {
+
+  private final String bucket;
+  private final String prefix;
+
+  public BackupS3Properties(String bucket, String prefix) {
+    this.bucket = bucket;
+    this.prefix = prefix;
+  }
+
+}

--- a/src/main/java/com/example/monewteam08/controller/ArticleController.java
+++ b/src/main/java/com/example/monewteam08/controller/ArticleController.java
@@ -1,5 +1,6 @@
 package com.example.monewteam08.controller;
 
+import com.example.monewteam08.controller.api.ArticleControllerDocs;
 import com.example.monewteam08.dto.response.article.ArticleDto;
 import com.example.monewteam08.dto.response.article.ArticleViewDto;
 import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/articles")
 @RequiredArgsConstructor
-public class ArticleController {
+public class ArticleController implements ArticleControllerDocs {
 
   private final ArticleService articleService;
   private final ArticleViewService articleViewService;
@@ -36,18 +37,21 @@ public class ArticleController {
     return ResponseEntity.ok(articles);
   }
 
+  @Override
   @DeleteMapping("/{articleId}")
   public ResponseEntity<Void> softDelete(@PathVariable UUID articleId) {
     articleService.softDelete(articleId);
     return ResponseEntity.noContent().build();
   }
 
+  @Override
   @DeleteMapping("/{articleId}/hard")
   public ResponseEntity<Void> hardDelete(@PathVariable UUID articleId) {
     articleService.hardDelete(articleId);
     return ResponseEntity.noContent().build();
   }
 
+  @Override
   @GetMapping
   public ResponseEntity<CursorPageResponseArticleDto> getArticles(
       @RequestParam(required = false) String keyword,
@@ -78,6 +82,7 @@ public class ArticleController {
     return ResponseEntity.ok(response);
   }
 
+  @Override
   @PostMapping("/{articleId}/article-views")
   public ResponseEntity<ArticleViewDto> registerArticleView(
       @PathVariable UUID articleId,

--- a/src/main/java/com/example/monewteam08/controller/api/ArticleControllerDocs.java
+++ b/src/main/java/com/example/monewteam08/controller/api/ArticleControllerDocs.java
@@ -1,0 +1,98 @@
+package com.example.monewteam08.controller.api;
+
+import com.example.monewteam08.dto.response.article.ArticleViewDto;
+import com.example.monewteam08.dto.response.article.CursorPageResponseArticleDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "뉴스 기사 관리", description = "뉴스 기사 관리 API")
+@RequestMapping("/api/articles")
+public interface ArticleControllerDocs {
+
+  @Operation(summary = "기사 논리 삭제", description = "기사를 논리적으로 석제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204", description = "논리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404", description = "기사를 찾을 수 없음"
+      ),
+      @ApiResponse(
+          responseCode = "500", description = "서버 내부 오류"
+      )
+  })
+  ResponseEntity<Void> softDelete(@PathVariable UUID articleId);
+
+  @Operation(summary = "기사 물리 삭제", description = "기사를 물리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204", description = "물리 삭제 성공"
+      ),
+      @ApiResponse(
+          responseCode = "404", description = "기사를 찾을 수 없음"
+      ),
+      @ApiResponse(
+          responseCode = "500", description = "서버 내부 오류"
+      )
+  })
+  ResponseEntity<Void> hardDelete(@PathVariable UUID articleId);
+
+  @Operation(summary = "기사 목록 조회", description = "조건에 맞는 기사 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "조회 성공",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseArticleDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "400", description = "잘못된 요청 (정렬 기준 오류, 페이지네이션 파라미터 오류 등)",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseArticleDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = CursorPageResponseArticleDto.class))
+      )
+  })
+  ResponseEntity<CursorPageResponseArticleDto> getArticles(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) UUID interestId,
+      @RequestParam(required = false) List<String> sourceIn,
+      @RequestParam(required = false) LocalDateTime publishDateFrom,
+      @RequestParam(required = false) LocalDateTime publishDateTo,
+      @RequestParam String orderBy,
+      @RequestParam String direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) LocalDateTime after, //createdAt
+      @RequestParam(defaultValue = "10") Integer limit,
+      @RequestHeader(name = "Monew-Request-User-Id") UUID monewRequestUserId);
+
+  @Operation(summary = "기사 뷰 등록", description = "기사 뷰를 등록합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200", description = "기사 뷰 등록 성공",
+          content = @Content(schema = @Schema(implementation = ArticleViewDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "404", description = "기사를 찾을 수 없음"
+      ),
+      @ApiResponse(
+          responseCode = "500", description = "서버 내부 오류"
+      )
+  })
+  ResponseEntity<ArticleViewDto> registerArticleView(
+      @PathVariable UUID articleId,
+      @RequestHeader(name = "Monew-Request-User-Id") UUID userId
+  );
+
+}

--- a/src/main/java/com/example/monewteam08/service/Interface/CsvService.java
+++ b/src/main/java/com/example/monewteam08/service/Interface/CsvService.java
@@ -2,12 +2,11 @@ package com.example.monewteam08.service.Interface;
 
 import com.example.monewteam08.entity.Article;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.util.List;
 
 public interface CsvService {
 
-  Path exportArticlesToCsv(LocalDate date, List<Article> articles);
+  Path exportArticlesToCsv(Path path, List<Article> articles);
 
   List<Article> importArticlesFromCsv(Path filePath);
 

--- a/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
@@ -10,7 +10,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +24,7 @@ import org.springframework.stereotype.Service;
 public class CsvServiceImpl implements CsvService {
 
   @Override
-  public Path exportArticlesToCsv(LocalDate date, List<Article> articles) {
-    String fileName = "articles_" + date + ".csv";
-    Path path = Path.of(System.getProperty("java.io.tmpdir"), fileName);
+  public Path exportArticlesToCsv(Path path, List<Article> articles) {
 
     try (CSVWriter writer = new CSVWriter(new FileWriter(path.toFile()))) {
       String[] header = {"id", "source", "title", "summary", "sourceUrl", "publishDate",

--- a/src/main/java/com/example/monewteam08/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/S3ServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.monewteam08.service.impl;
 
+import com.example.monewteam08.config.BackupS3Properties;
 import com.example.monewteam08.service.Interface.S3Service;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -7,27 +8,29 @@ import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service {
 
-//  private final S3Client s3Client;
-//  private final String bucketName = ""; // TODO: S3 버킷 이름 추가
-//  private final BackupS3Properties backupS3Properties;
+  private final S3Client s3Client;
+  private final BackupS3Properties backupS3Properties;
 
   @Override
   public void upload(Path path, LocalDate date) {
-//    String key = generateKey(date);
-//    PutObjectRequest request = PutObjectRequest.builder()
-//        .bucket(backupS3Properties.getBucket())
-//        .key(key)
-//        .contentType("text/csv")
-//        .build();
-//
-//    s3Client.putObject(request, path);
-//    log.info("Uploaded file to S3: {}", key);
+    String key = generateKey(date);
+    PutObjectRequest request = PutObjectRequest.builder()
+        .bucket(backupS3Properties.getBucket())
+        .key(key)
+        .contentType("text/csv")
+        .build();
+
+    s3Client.putObject(request, path);
+    log.info("Uploaded file to S3: {}", key);
   }
 
   @Override
@@ -35,13 +38,13 @@ public class S3ServiceImpl implements S3Service {
     String key = generateKey(date);
     Path downloadPath = Path.of(System.getProperty("java.io.tmpdir"), key.replace("/", "_"));
 
-//    GetObjectRequest request = GetObjectRequest.builder()
-//        .bucket(bucketName)
-//        .key(key)
-//        .build();
-//
-//    s3Client.getObject(request, downloadPath);
-//    log.info("Downloaded file from S3: {}", downloadPath);
+    GetObjectRequest request = GetObjectRequest.builder()
+        .bucket(backupS3Properties.getBucket())
+        .key(key)
+        .build();
+
+    s3Client.getObject(request, downloadPath);
+    log.info("Downloaded file from S3: {}", downloadPath);
 
     return downloadPath;
   }
@@ -49,7 +52,6 @@ public class S3ServiceImpl implements S3Service {
   private String generateKey(LocalDate date) {
     String datePath = date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
     String fileName = "articles_" + date.format(DateTimeFormatter.ISO_DATE) + ".csv";
-//    return backupS3Properties.getPrefix() + datePath + "/" + fileName;
-    return "";
+    return backupS3Properties.getPrefix() + datePath + "/" + fileName;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,8 @@ spring:
 logging:
   level:
     root: info
+
+backup:
+  s3:
+    bucket: ${AWS_S3_BUCKET}
+    prefix: ${BACKUP_S3_STORAGE_PATH}

--- a/src/test/java/com/example/monewteam08/repository/ArticleRepositoryCustomTest.java
+++ b/src/test/java/com/example/monewteam08/repository/ArticleRepositoryCustomTest.java
@@ -81,8 +81,9 @@ class ArticleRepositoryCustomTest {
   @Test
   void 발행일_범위_검색_성공() {
     // given
-    LocalDateTime from = LocalDateTime.now().minusDays(1).toLocalDate().atStartOfDay();
-    LocalDateTime to = LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.of(2025, 4, 28, 0, 0, 0);
+    LocalDateTime from = now.minusDays(1);
+    LocalDateTime to = now;
 
     // when
     List<Article> articles = articleRepository.findAllByCursor(null, null, null, from, to,
@@ -122,11 +123,11 @@ class ArticleRepositoryCustomTest {
   @Test
   void 발행일_범위_카운트_성공() {
     // given
-    LocalDateTime from = LocalDateTime.now().minusDays(3);
-    LocalDateTime to = LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.of(2025, 4, 28, 0, 0, 0);
+    LocalDateTime from = now.minusDays(3);
 
     // when
-    long count = articleRepository.countAllByCondition(null, null, null, from, to);
+    long count = articleRepository.countAllByCondition(null, null, null, from, now);
 
     // then
     assertThat(count).isEqualTo(3);

--- a/src/test/java/com/example/monewteam08/service/impl/ArticleBackupServiceTest.java
+++ b/src/test/java/com/example/monewteam08/service/impl/ArticleBackupServiceTest.java
@@ -1,0 +1,78 @@
+package com.example.monewteam08.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.monewteam08.entity.Article;
+import com.example.monewteam08.repository.ArticleRepository;
+import com.example.monewteam08.service.Interface.CsvService;
+import com.example.monewteam08.service.Interface.S3Service;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleBackupServiceTest {
+
+  @Mock
+  private ArticleRepository articleRepository;
+
+  @Mock
+  private CsvService csvService;
+
+  @Mock
+  private S3Service s3Service;
+
+  @InjectMocks
+  private ArticleBackupServiceImpl articleBackupService;
+
+  @Test
+  void 백업_성공() {
+    // given
+    LocalDate yesterday = LocalDate.now().minusDays(1);
+    List<Article> articles = List.of(
+        Article.withId(UUID.randomUUID(), "NAVER", "제목", "요약", "http://test.com",
+            yesterday.minusDays(1).atTime(8, 0), null)
+    );
+
+    when(articleRepository.findAllByPublishDateBetween(any(), any()))
+        .thenReturn(articles);
+    when(csvService.exportArticlesToCsv(any(Path.class), eq(articles)))
+        .thenReturn(Path.of("/tmp/articles_" + yesterday + ".csv"));
+
+    // when
+    articleBackupService.backup();
+
+    // then
+    verify(s3Service).upload(any(Path.class), eq(yesterday));
+  }
+
+  @Test
+  void 복구_성공() {
+    // given
+    LocalDate today = LocalDate.now();
+    Path dummyPath = Path.of("/tmp/articles_" + today + ".csv");
+
+    List<Article> articles = List.of(
+        Article.withId(UUID.randomUUID(), "NAVER", "제목", "요약", "http://test.com",
+            today.minusDays(1).atTime(8, 0), null)
+    );
+
+    when(s3Service.download(today)).thenReturn(dummyPath);
+    when(csvService.importArticlesFromCsv(dummyPath)).thenReturn(articles);
+
+    // when
+    articleBackupService.restore(today);
+
+    // then
+    verify(articleRepository).saveAll(articles);
+  }
+}

--- a/src/test/java/com/example/monewteam08/service/impl/CsvServiceTest.java
+++ b/src/test/java/com/example/monewteam08/service/impl/CsvServiceTest.java
@@ -23,20 +23,23 @@ public class CsvServiceTest {
   void CSV로_내보내기_성공() {
     // given
     CsvService csvService = new CsvServiceImpl();
-    LocalDate today = LocalDate.now();
+    LocalDate yesterday = LocalDate.now().minusDays(1);
     UUID articleId = UUID.randomUUID();
     Article article = new Article("NAVER", "title", "summary", "http://example.com",
         LocalDateTime.now(), null);
     List<Article> articles = List.of(article);
     ReflectionTestUtils.setField(article, "id", articleId);
 
+    String fileName = "articles_" + yesterday + ".csv";
+    Path tmpPath = Path.of(System.getProperty("java.io.tmpdir"), fileName);
+
     // when
-    Path path = csvService.exportArticlesToCsv(LocalDate.now(), articles);
+    Path path = csvService.exportArticlesToCsv(tmpPath, articles);
 
     //then
     assertThat(path).isNotNull();
     assertThat(Files.exists(path)).isTrue();
-    assertThat(path.toString()).contains("articles_" + today + ".csv");
+    assertThat(path.toString()).contains("articles_" + yesterday + ".csv");
   }
 
   @Test

--- a/src/test/java/com/example/monewteam08/service/impl/S3ServiceImplTest.java
+++ b/src/test/java/com/example/monewteam08/service/impl/S3ServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.example.monewteam08.service.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.monewteam08.config.BackupS3Properties;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceImplTest {
+
+  @Mock
+  private S3Client s3Client;
+
+  @Mock
+  private BackupS3Properties backupS3Properties;
+
+  @InjectMocks
+  private S3ServiceImpl s3Service;
+
+  @Test
+  void S3_업로드_성공() {
+    // given
+    LocalDate date = LocalDate.of(2025, 4, 29);
+    Path filePath = Path.of("/tmp/articles_2025-04-29.csv");
+
+    when(backupS3Properties.getBucket()).thenReturn("monew-storage");
+    when(backupS3Properties.getPrefix()).thenReturn("backups/articles/");
+
+    // when
+    s3Service.upload(filePath, date);
+
+    // then
+    verify(s3Client).putObject(any(PutObjectRequest.class), eq(filePath));
+  }
+
+  @Test
+  void S3_다운로드_성공() {
+    // given
+    LocalDate date = LocalDate.of(2025, 4, 29);
+
+    when(backupS3Properties.getBucket()).thenReturn("monew-backup-storage");
+    when(backupS3Properties.getPrefix()).thenReturn("backups/articles/");
+
+    // when
+    Path result = s3Service.download(date);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(s3Client).getObject(any(GetObjectRequest.class), any(Path.class));
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #62 

### 🎯 PR 개요

- S3 업로드, 다운로드 로직 추가 및 단위테스트

### 📑 작업 내용

- `ArticleController` 스웨거 문서 추가
- 테스트에서 현재 날짜 고정하도록 수정
- S3에 csv 파일 업로드, 다운로드하는 로직 추가

#### 🛠 테스트 내용 (선택)
- `ArticleBackupServiceTest` 에서 백업, 복구 단위테스트

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.