### PR TITLE
Feat: 논리 삭제된 기사 복구

### DIFF
--- a/src/main/java/com/example/monewteam08/entity/Article.java
+++ b/src/main/java/com/example/monewteam08/entity/Article.java
@@ -77,6 +77,10 @@ public class Article {
     this.isActive = false;
   }
 
+  public void activate() {
+    this.isActive = true;
+  }
+
   public void addViewCount() {
     this.viewCount++;
   }

--- a/src/main/java/com/example/monewteam08/service/impl/ArticleFetchServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/ArticleFetchServiceImpl.java
@@ -57,8 +57,7 @@ public class ArticleFetchServiceImpl implements ArticleFetchService {
     List<Article> articles = new ArrayList<>();
     articles.addAll(fetchNaverArticles());
     articles.addAll(fetchRssArticles("YONHAP", YONHAP_RSS_URL));
-    articles.addAll(
-        fetchRssArticles("CHOSUN", CHOSUN_RSS_URL));
+    articles.addAll(fetchRssArticles("CHOSUN", CHOSUN_RSS_URL));
     articles.addAll(fetchRssArticles("HANKYUNG", HANKYUNG_RSS_URL));
     return articles;
   }
@@ -68,7 +67,7 @@ public class ArticleFetchServiceImpl implements ArticleFetchService {
     String uri = UriComponentsBuilder
         .fromHttpUrl(NAVER_API_URL)
         .queryParam("query", "뉴스")
-        .queryParam("display", 10)
+        .queryParam("display", 100)
         .queryParam("start", 1)
         .queryParam("sort", "date")
         .toUriString();

--- a/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
@@ -63,7 +63,7 @@ public class CsvServiceImpl implements CsvService {
               nextLine[3],
               nextLine[4],
               LocalDateTime.parse(nextLine[5]),
-              nextLine[6] != null && !nextLine[6].isBlank()
+              nextLine[6] != null && !nextLine[6].isBlank() && !nextLine[6].equals("null")
                   ? UUID.fromString(nextLine[6])
                   : null
           );

--- a/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
+++ b/src/main/java/com/example/monewteam08/service/impl/CsvServiceImpl.java
@@ -63,8 +63,7 @@ public class CsvServiceImpl implements CsvService {
               nextLine[3],
               nextLine[4],
               LocalDateTime.parse(nextLine[5]),
-              nextLine[6] != null
-                  && !"null".equalsIgnoreCase(nextLine[6])
+              nextLine[6] != null && !nextLine[6].isBlank()
                   ? UUID.fromString(nextLine[6])
                   : null
           );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,8 @@ backup:
   s3:
     bucket: ${AWS_S3_BUCKET}
     prefix: ${BACKUP_S3_STORAGE_PATH}
+
+naver:
+  api:
+    client-id: ${NAVER_API_CLIENT_ID}
+    client-secret: ${NAVER_API_CLIENT_SECRET}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #62 

### 🎯 PR 개요

- 네이버 기사 버그 수정
- 기사 복구 버그 수정
- 논리 삭제된 기사 복구하는 기능 추가

### 📑 작업 내용

- `application.yml` 에 네이버 api 관련 키 추가
- 관심사 id 변환 시 null인 경우 조건 추가
- 유실 기사 복구 시 논리삭제된 기사도 복구하도록 로직 추가

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.